### PR TITLE
Simplify benchmark output

### DIFF
--- a/scripts/all.sh
+++ b/scripts/all.sh
@@ -4,7 +4,7 @@
 #######################
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 declare -a commands=('bitset_benchmarks' 'stl_vector_benchmarks' 'stl_vector_benchmarks_memtracked' 'stl_hashset_benchmarks_memtracked' 'stl_hashset_benchmarks' 'bitmagic_benchmarks'  'bitmagic_benchmarks -r' 'slow_roaring_benchmarks -r' 'malloced_roaring_benchmarks -r' 'roaring_benchmarks -r' 'roaring_benchmarks -c -r' 'roaring_benchmarks' 'roaring_benchmarks -c'   'ewah32_benchmarks'  'ewah64_benchmarks' 'wah32_benchmarks' 'concise_benchmarks' );
-echo "# For each data set, we print data size (in bits per value), successive intersections, successive unions and total unions [we compute the total  union first naively and then (if supported) using a heap-based approach], followed by quartile point queries (in cycles per input value), successive differences, successive symmetric differences, iterations through all values, then we have pairwise count aggregates for successive intersections, successive unions, successive differences, successive symmetric differences "
+echo "# For each data set we report the compression ratio (bits per value), the compression speed (cycles per byte) and the decompression speed (cycles per byte)"
 for f in  census-income census-income_srt census1881  census1881_srt  weather_sept_85  weather_sept_85_srt wikileaks-noquotes  wikileaks-noquotes_srt ; do
   echo "# processing file " $f
   for t in "${commands[@]}"; do

--- a/src/bitmagic_benchmarks.cpp
+++ b/src/bitmagic_benchmarks.cpp
@@ -179,6 +179,7 @@ int main(int argc, char **argv) {
     RDTSC_START(cycles_start);
     std::vector<bvect > bitmaps = create_all_bitmaps(howmany, numbers, count, memorysavingmode);
     RDTSC_FINAL(cycles_final);
+    uint64_t build_cycles = cycles_final - cycles_start;
     if (bitmaps.empty()) return -1;
     if(verbose) printf("Loaded %d bitmaps from directory %s \n", (int)count, dirname);
     uint64_t totalsize = 0;
@@ -351,20 +352,10 @@ int main(int argc, char **argv) {
     */
 
 
-    printf(" %20.2f %20.2f %20.2f %20.2f %20.2f %20.2f  %20.2f  %20.2f     %20.2f    %20.2f  %20.2f  %20.2f  %20.2f\n",
+    printf(" %20.2f %20.2f %20.2f\n",
       data[0]*8.0/totalcard,
-      data[1]*1.0/successivecard,
-      data[2]*1.0/successivecard,
-      data[3]*1.0/totalcard,
-      data[4]*1.0/totalcard,
-      data[5]*1.0/(3*count),
-      data[6]*1.0/successivecard,
-      data[7]*1.0/successivecard,
-      data[8]*1.0/totalcard,
-      data[9]*1.0/successivecard,
-      data[10]*1.0/successivecard,
-      data[11]*1.0/successivecard,
-      data[12]*1.0/successivecard
+      build_cycles*1.0/(totalcard*4),
+      data[8]*1.0/(totalcard*4)
      );
 
 

--- a/src/bitset_benchmarks.c
+++ b/src/bitset_benchmarks.c
@@ -102,6 +102,7 @@ int main(int argc, char **argv) {
     RDTSC_START(cycles_start);
     bitset_t **bitmaps = create_all_bitmaps(howmany, numbers, count);
     RDTSC_FINAL(cycles_final);
+    uint64_t build_cycles = cycles_final - cycles_start;
     if (bitmaps == NULL) return -1;
     if(verbose) printf("Loaded %d bitmaps from directory %s \n", (int)count, dirname);
     uint64_t totalsize = 0;
@@ -276,20 +277,10 @@ int main(int argc, char **argv) {
     /**
     * end and, or, andnot and xor cardinality
     */
-    printf(" %20.2f %20.2f %20.2f %20.2f %20.2f %20.2f  %20.2f  %20.2f     %20.2f    %20.2f  %20.2f  %20.2f  %20.2f\n",
+    printf(" %20.2f %20.2f %20.2f\n",
       data[0]*8.0/totalcard,
-      data[1]*1.0/successivecard,
-      data[2]*1.0/successivecard,
-      data[3]*1.0/totalcard,
-      data[4]*1.0/totalcard,
-      data[5]*1.0/(3*count),
-      data[6]*1.0/successivecard,
-      data[7]*1.0/successivecard,
-      data[8]*1.0/totalcard,
-      data[9]*1.0/successivecard,
-      data[10]*1.0/successivecard,
-      data[11]*1.0/successivecard,
-      data[12]*1.0/successivecard
+      build_cycles*1.0/(totalcard*4),
+      data[8]*1.0/(totalcard*4)
     );
     for (int i = 0; i < (int)count; ++i) {
         free(numbers[i]);

--- a/src/concise_benchmarks.cpp
+++ b/src/concise_benchmarks.cpp
@@ -105,6 +105,7 @@ int main(int argc, char **argv) {
     RDTSC_START(cycles_start);
     std::vector<ConciseSet<false> > bitmaps = create_all_bitmaps(howmany, numbers, count);
     RDTSC_FINAL(cycles_final);
+    uint64_t build_cycles = cycles_final - cycles_start;
     if (bitmaps.empty()) return -1;
     if(verbose) printf("Loaded %d bitmaps from directory %s \n", (int)count, dirname);
     uint64_t totalsize = 0;
@@ -272,20 +273,10 @@ int main(int argc, char **argv) {
     * end and, or, andnot and xor cardinality
     */
 
-    printf(" %20.2f %20.2f %20.2f %20.2f %20.2f %20.2f  %20.2f  %20.2f     %20.2f    %20.2f  %20.2f  %20.2f  %20.2f\n",
+    printf(" %20.2f %20.2f %20.2f\n",
       data[0]*8.0/totalcard,
-      data[1]*1.0/successivecard,
-      data[2]*1.0/successivecard,
-      data[3]*1.0/totalcard,
-      data[4]*1.0/totalcard,
-      data[5]*1.0/(3*count),
-      data[6]*1.0/successivecard,
-      data[7]*1.0/successivecard,
-      data[8]*1.0/totalcard,
-      data[9]*1.0/successivecard,
-      data[10]*1.0/successivecard,
-      data[11]*1.0/successivecard,
-      data[12]*1.0/successivecard
+      build_cycles*1.0/(totalcard*4),
+      data[8]*1.0/(totalcard*4)
     );
     for (int i = 0; i < (int)count; ++i) {
         free(numbers[i]);

--- a/src/ewah32_benchmarks.cpp
+++ b/src/ewah32_benchmarks.cpp
@@ -104,6 +104,7 @@ int main(int argc, char **argv) {
     RDTSC_START(cycles_start);
     std::vector<EWAHBoolArray<uint32_t> > bitmaps = create_all_bitmaps(howmany, numbers, count);
     RDTSC_FINAL(cycles_final);
+    uint64_t build_cycles = cycles_final - cycles_start;
     if (bitmaps.empty()) return -1;
     if(verbose) printf("Loaded %d bitmaps from directory %s \n", (int)count, dirname);
     uint64_t totalsize = 0;
@@ -282,20 +283,10 @@ int main(int argc, char **argv) {
     * end and, or, andnot and xor cardinality
     */
 
-    printf(" %20.2f %20.2f %20.2f %20.2f %20.2f %20.2f  %20.2f  %20.2f     %20.2f    %20.2f  %20.2f  %20.2f  %20.2f\n",
+    printf(" %20.2f %20.2f %20.2f\n",
       data[0]*8.0/totalcard,
-      data[1]*1.0/successivecard,
-      data[2]*1.0/successivecard,
-      data[3]*1.0/totalcard,
-      data[4]*1.0/totalcard,
-      data[5]*1.0/(3*count),
-      data[6]*1.0/successivecard,
-      data[7]*1.0/successivecard,
-      data[8]*1.0/totalcard,
-      data[9]*1.0/successivecard,
-      data[10]*1.0/successivecard,
-      data[11]*1.0/successivecard,
-      data[12]*1.0/successivecard
+      build_cycles*1.0/(totalcard*4),
+      data[8]*1.0/(totalcard*4)
     );
     for (int i = 0; i < (int)count; ++i) {
         free(numbers[i]);

--- a/src/ewah64_benchmarks.cpp
+++ b/src/ewah64_benchmarks.cpp
@@ -103,6 +103,7 @@ int main(int argc, char **argv) {
     RDTSC_START(cycles_start);
     std::vector<EWAHBoolArray<uint64_t> > bitmaps = create_all_bitmaps(howmany, numbers, count);
     RDTSC_FINAL(cycles_final);
+    uint64_t build_cycles = cycles_final - cycles_start;
     if (bitmaps.empty()) return -1;
     if(verbose) printf("Loaded %d bitmaps from directory %s \n", (int)count, dirname);
     uint64_t totalsize = 0;
@@ -281,20 +282,10 @@ int main(int argc, char **argv) {
     assert(total_count == totalcard);
 
 
-    printf(" %20.2f %20.2f %20.2f %20.2f %20.2f %20.2f  %20.2f  %20.2f     %20.2f    %20.2f  %20.2f  %20.2f  %20.2f\n",
+    printf(" %20.2f %20.2f %20.2f\n",
       data[0]*8.0/totalcard,
-      data[1]*1.0/successivecard,
-      data[2]*1.0/successivecard,
-      data[3]*1.0/totalcard,
-      data[4]*1.0/totalcard,
-      data[5]*1.0/(3*count),
-      data[6]*1.0/successivecard,
-      data[7]*1.0/successivecard,
-      data[8]*1.0/totalcard,
-      data[9]*1.0/successivecard,
-      data[10]*1.0/successivecard,
-      data[11]*1.0/successivecard,
-      data[12]*1.0/successivecard
+      build_cycles*1.0/(totalcard*4),
+      data[8]*1.0/(totalcard*4)
     );
 
 

--- a/src/roaring_benchmarks.c
+++ b/src/roaring_benchmarks.c
@@ -131,6 +131,7 @@ int main(int argc, char **argv) {
     uint64_t totalsize = 0;
     roaring_bitmap_t **bitmaps = create_all_bitmaps(howmany, numbers, count,runoptimize,copyonwrite, verbose, &totalsize);
     RDTSC_FINAL(cycles_final);
+    uint64_t build_cycles = cycles_final - cycles_start;
     if (bitmaps == NULL) return -1;
     if(verbose) printf("Loaded %d bitmaps from directory %s \n", (int)count, dirname);
     data[0] = totalsize;
@@ -300,20 +301,10 @@ int main(int argc, char **argv) {
     */
 
 
-    printf(" %20.2f %20.2f %20.2f %20.2f %20.2f %20.2f  %20.2f  %20.2f     %20.2f    %20.2f  %20.2f  %20.2f  %20.2f\n",
+    printf(" %20.2f %20.2f %20.2f\n",
            data[0]*8.0/totalcard,
-           data[1]*1.0/successivecard,
-           data[2]*1.0/successivecard,
-           data[3]*1.0/totalcard,
-           data[4]*1.0/totalcard,
-           data[5]*1.0/(3*count),
-           data[6]*1.0/successivecard,
-           data[7]*1.0/successivecard,
-           data[8]*1.0/totalcard,
-           data[9]*1.0/successivecard,
-           data[10]*1.0/successivecard,
-           data[11]*1.0/successivecard,
-           data[12]*1.0/successivecard
+           build_cycles*1.0/(totalcard*4),
+           data[8]*1.0/(totalcard*4)
           );
 
     for (int i = 0; i < (int)count; ++i) {

--- a/src/stl_hashset_benchmarks.cpp
+++ b/src/stl_hashset_benchmarks.cpp
@@ -206,6 +206,7 @@ int main(int argc, char **argv) {
     RDTSC_START(cycles_start);
     std::vector<hashset > bitmaps = create_all_bitmaps(howmany, numbers, count);
     RDTSC_FINAL(cycles_final);
+    uint64_t build_cycles = cycles_final - cycles_start;
     if (bitmaps.empty()) return -1;
     if(verbose) printf("Loaded %d bitmaps from directory %s \n", (int)count, dirname);
     uint64_t totalsize = getMemUsageInBytes();
@@ -374,20 +375,10 @@ int main(int argc, char **argv) {
     /**
     * end and, or, andnot and xor cardinality
     */
-    printf(" %20.2f %20.2f %20.2f %20.2f %20.2f %20.2f  %20.2f  %20.2f     %20.2f    %20.2f  %20.2f  %20.2f  %20.2f\n",
+    printf(" %20.2f %20.2f %20.2f\n",
       data[0]*8.0/totalcard,
-      data[1]*1.0/successivecard,
-      data[2]*1.0/successivecard,
-      data[3]*1.0/totalcard,
-      data[4]*1.0/totalcard,
-      data[5]*1.0/(3*count),
-      data[6]*1.0/successivecard,
-      data[7]*1.0/successivecard,
-      data[8]*1.0/totalcard,
-      data[9]*1.0/successivecard,
-      data[10]*1.0/successivecard,
-      data[11]*1.0/successivecard,
-      data[12]*1.0/successivecard
+      build_cycles*1.0/(totalcard*4),
+      data[8]*1.0/(totalcard*4)
     );
 
     for (int i = 0; i < (int)count; ++i) {

--- a/src/stl_vector_benchmarks.cpp
+++ b/src/stl_vector_benchmarks.cpp
@@ -206,6 +206,7 @@ int main(int argc, char **argv) {
     RDTSC_START(cycles_start);
     std::vector<vector> bitmaps = create_all_bitmaps(howmany, numbers, count);
     RDTSC_FINAL(cycles_final);
+    uint64_t build_cycles = cycles_final - cycles_start;
     if (bitmaps.empty()) return -1;
     if(verbose) printf("Loaded %d bitmaps from directory %s \n", (int)count, dirname);
     uint64_t totalsize = getMemUsageInBytes();
@@ -374,20 +375,10 @@ int main(int argc, char **argv) {
     * end and, or, andnot and xor cardinality
     */
 
-    printf(" %20.2f %20.2f %20.2f %20.2f %20.2f %20.2f  %20.2f  %20.2f     %20.2f    %20.2f  %20.2f  %20.2f  %20.2f\n",
+    printf(" %20.2f %20.2f %20.2f\n",
       data[0]*8.0/totalcard,
-      data[1]*1.0/successivecard,
-      data[2]*1.0/successivecard,
-      data[3]*1.0/totalcard,
-      data[4]*1.0/totalcard,
-      data[5]*1.0/(3*count),
-      data[6]*1.0/successivecard,
-      data[7]*1.0/successivecard,
-      data[8]*1.0/totalcard,
-      data[9]*1.0/successivecard,
-      data[10]*1.0/successivecard,
-      data[11]*1.0/successivecard,
-      data[12]*1.0/successivecard
+      build_cycles*1.0/(totalcard*4),
+      data[8]*1.0/(totalcard*4)
     );
 
     for (int i = 0; i < (int)count; ++i) {

--- a/src/wah32_benchmarks.cpp
+++ b/src/wah32_benchmarks.cpp
@@ -104,6 +104,7 @@ int main(int argc, char **argv) {
     RDTSC_START(cycles_start);
     std::vector<ConciseSet<true> > bitmaps = create_all_bitmaps(howmany, numbers, count);
     RDTSC_FINAL(cycles_final);
+    uint64_t build_cycles = cycles_final - cycles_start;
     if (bitmaps.empty()) return -1;
     if(verbose) printf("Loaded %d bitmaps from directory %s \n", (int)count, dirname);
     uint64_t totalsize = 0;
@@ -269,20 +270,10 @@ int main(int argc, char **argv) {
     * end and, or, andnot and xor cardinality
     */
 
-    printf(" %20.2f %20.2f %20.2f %20.2f %20.2f %20.2f  %20.2f  %20.2f     %20.2f    %20.2f  %20.2f  %20.2f  %20.2f\n",
+    printf(" %20.2f %20.2f %20.2f\n",
       data[0]*8.0/totalcard,
-      data[1]*1.0/successivecard,
-      data[2]*1.0/successivecard,
-      data[3]*1.0/totalcard,
-      data[4]*1.0/totalcard,
-      data[5]*1.0/(3*count),
-      data[6]*1.0/successivecard,
-      data[7]*1.0/successivecard,
-      data[8]*1.0/totalcard,
-      data[9]*1.0/successivecard,
-      data[10]*1.0/successivecard,
-      data[11]*1.0/successivecard,
-      data[12]*1.0/successivecard
+      build_cycles*1.0/(totalcard*4),
+      data[8]*1.0/(totalcard*4)
     );
 
 


### PR DESCRIPTION
## Summary
- trim info message in the runner script
- output compression ratio, compression speed and decompression speed only
- track bitmap creation time to compute compression speed

## Testing
- `make` *(fails: concise.h missing)*

------
https://chatgpt.com/codex/tasks/task_e_6848f469ee68832686138cffd1d859c5