### PR TITLE
Enable CSV results for benchmark scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -367,6 +367,9 @@ $ make test
                  2.23                 1.43                 2.63               149.06                13.71               497.06                  1.99                  2.66                     9.23                    0.83                  1.16                  1.03                  1.16
 ```
 
+Running `scripts/all.sh` now also writes a CSV file to `scripts/results.csv`
+containing the dataset name, test command, compression ratio, compression speed
+and decompression speed.
 
 ```bash
 $ ./scripts/big.sh
@@ -421,6 +424,7 @@ ences, successive symmetric differences
       37.83                    27.60                   18.91                 19.30                 18.90                 19.19
 ```
 
+`scripts/big.sh` also writes to `scripts/results.csv` using the large synthetic dataset.
 
 ## Usage
 

--- a/scripts/all.sh
+++ b/scripts/all.sh
@@ -3,13 +3,21 @@
 # To add a technique, simply append the file name of your executable to the commands array below
 #######################
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+CSV_FILE="$DIR/results.csv"
+echo "dataset,test,ratio,speed,decspeed" > "$CSV_FILE"
 declare -a commands=('bitset_benchmarks' 'stl_vector_benchmarks' 'stl_vector_benchmarks_memtracked' 'stl_hashset_benchmarks_memtracked' 'stl_hashset_benchmarks' 'bitmagic_benchmarks'  'bitmagic_benchmarks -r' 'slow_roaring_benchmarks -r' 'malloced_roaring_benchmarks -r' 'roaring_benchmarks -r' 'roaring_benchmarks -c -r' 'roaring_benchmarks' 'roaring_benchmarks -c'   'ewah32_benchmarks'  'ewah64_benchmarks' 'wah32_benchmarks' 'concise_benchmarks' );
 echo "# For each data set we report the compression ratio (percentage of the uncompressed size), the compression speed (cycles per byte) and the decompression speed (cycles per byte)"
 for f in  census-income census-income_srt census1881  census1881_srt  weather_sept_85  weather_sept_85_srt wikileaks-noquotes  wikileaks-noquotes_srt ; do
   echo "# processing file " $f
   for t in "${commands[@]}"; do
      echo "#" $t
-    ./$t CRoaring/benchmarks/realdata/$f;
+    output=$(./$t CRoaring/benchmarks/realdata/$f)
+    echo "$output"
+    lastline=$(echo "$output" | grep -E '^[0-9 .]+$' | tail -n 1)
+    ratio=$(echo "$lastline" | awk '{print $1}')
+    speed=$(echo "$lastline" | awk '{print $2}')
+    decspeed=$(echo "$lastline" | awk '{print $3}')
+    echo "$f,$t,$ratio,$speed,$decspeed" >> "$CSV_FILE"
   done
   echo
   echo

--- a/scripts/big.sh
+++ b/scripts/big.sh
@@ -3,10 +3,18 @@
 # To add a technique, simply append the file name of your executable to the commands array below
 #######################
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+CSV_FILE="$DIR/results.csv"
+echo "dataset,test,ratio,speed,decspeed" > "$CSV_FILE"
 ${DIR}/generatebig.sh
 declare -a commands=('bitset_benchmarks' 'stl_vector_benchmarks' 'stl_vector_benchmarks_memtracked' 'stl_hashset_benchmarks_memtracked' 'stl_hashset_benchmarks' 'bitmagic_benchmarks'  'bitmagic_benchmarks -r' 'slow_roaring_benchmarks -r' 'malloced_roaring_benchmarks -r' 'roaring_benchmarks -r' 'roaring_benchmarks -c -r' 'roaring_benchmarks' 'roaring_benchmarks -c'   'ewah32_benchmarks'  'ewah64_benchmarks' 'wah32_benchmarks' 'concise_benchmarks' );
 echo "# For each data set, we print data size (in percentage of the uncompressed size), successive intersections, successive unions and total unions [we compute the total  union first naively and then (if supported) using a heap-based approach], followed by quartile point queries (in cycles per input value), successive differences, successive symmetric differences, iterations through all values, then we have pairwise count aggregates for successive intersections, successive unions, successive differences, successive symmetric differences "
 for t in "${commands[@]}"; do
      echo "#" $t
-    ./$t bigtmp;
+    output=$(./$t bigtmp)
+    echo "$output"
+    lastline=$(echo "$output" | grep -E '^[0-9 .]+$' | tail -n 1)
+    ratio=$(echo "$lastline" | awk '{print $1}')
+    speed=$(echo "$lastline" | awk '{print $2}')
+    decspeed=$(echo "$lastline" | awk '{print $3}')
+    echo "bigtmp,$t,$ratio,$speed,$decspeed" >> "$CSV_FILE"
 done


### PR DESCRIPTION
## Summary
- emit CSV results in `scripts/all.sh`
- capture benchmark output in `scripts/big.sh`
- note generated CSV file in README

## Testing
- `make`
- `make test` *(fails: `./scripts/all.sh: line 14: ./wah32_benchmarks: No such file or directory`)*

------
https://chatgpt.com/codex/tasks/task_e_6848fe39ed588326bf004a92626b78a2